### PR TITLE
잘못된 환경변수 케이스 파싱에러 해결

### DIFF
--- a/src/parse_case_dquote.c
+++ b/src/parse_case_dquote.c
@@ -76,6 +76,16 @@ static void	fill_str(char *input, int *i, t_lst *env_lst, char **str)
 			(*i)++;
 		}
 	}
+	if (input[*i] == '$')
+	{
+		e_idx = 0;
+		env_str = parse_case_doller(input, i, env_lst);
+		if (!env_str)
+			return ;
+		while (env_str[e_idx])
+			(*str)[idx++] = env_str[e_idx++];
+		free(env_str);
+	}
 }
 
 char	*parse_case_dquote(char *input, int *i, t_lst *env_lst)


### PR DESCRIPTION
dquote에서 fill_str 에서
잘못된 환경변수 $ASF 이런게 들어오면
cnt_dquote_len 에서 0이 반환되고
while(idx<len) 반복문으로 안들어감

아래에 해당 케이스 추가