### PR TITLE
#48 시그널, 리다이렉션 오류 해결

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: tkim <tkim@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/12/14 17:12:43 by tkim              #+#    #+#             */
-/*   Updated: 2022/01/25 15:55:14 by tkim             ###   ########.fr       */
+/*   Updated: 2022/01/26 01:21:11 by tkim             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,8 @@
 # define REDIRECT4 4
 # define WORD -1
 # define FILE -2
+
+int	g_status;
 
 typedef struct s_lst
 {
@@ -112,6 +114,7 @@ char	**make_argv(t_token *token, t_lst *env_lst);
 t_cmd	*make_cmd(t_token *tokens, t_lst *env_lst);
 /*handle_signal.c*/
 int		handle_signal(void);
+void	handle_signal_child(void);
 /*print_util.c*/
 void	print_token(t_token *tokens);
 void	print_cmd(t_cmd *cmd);
@@ -122,6 +125,5 @@ void	fill_token_type(t_token *tokens);
 /*change_env.c*/
 void	convert_content(t_token **tokens, t_lst *env_lst);
 void	*close_fd(t_cmd *cmd);
-
 
 #endif

--- a/src/exec_func.c
+++ b/src/exec_func.c
@@ -1,7 +1,5 @@
 #include "minishell.h"
 
-extern int	g_status;
-
 int	exec_path(t_cmd *cmd, t_lst *env_lst, t_cmd *prev)
 {
 	int		ret;
@@ -16,23 +14,25 @@ int	exec_path(t_cmd *cmd, t_lst *env_lst, t_cmd *prev)
 	pid = fork();
 	if (pid > 0)
 	{
+		handle_signal_child();
 		waitpid(pid, &g_status, 0);
 		if (prev)
 			close(prev->pipe[0]);
 		close(cmd->pipe[1]);
 		free_2dim_arr(path_arr);
 		free_2dim_arr(env_arr);
+		handle_signal();
 	}
 	else if (pid == 0)
 	{
 		//set_redirection(cmd, prev);
 		if (cmd->fd_in != 0)
 			dup2(cmd->fd_in, 0);
-		if (prev && prev->is_pipe == 1)
+		else if (prev && prev->is_pipe == 1)
 			dup2(prev->pipe[0], 0);
 		if (cmd->fd_out != 1)
 			dup2(cmd->fd_out, 1);
-		if (cmd->is_pipe == 1)
+		else if (cmd->is_pipe == 1)
 			dup2(cmd->pipe[1], 1);
 		ret = execve(path, cmd->argv, env_arr);
 		if (ret == -1)

--- a/src/handle_signal.c
+++ b/src/handle_signal.c
@@ -1,5 +1,25 @@
 #include "minishell.h"
 
+static void	child_handler(int signo)
+{
+	if (signo == SIGINT)
+	{
+		write(2, "^C\n", 3);
+		g_status = 130;
+	}
+	if (signo == SIGQUIT)
+	{
+		write(2, "^\\Quit: 3\n", ft_strlen("^\\Quit: 3\n"));
+		g_status = 131;
+	}
+}
+
+void	handle_signal_child(void)
+{
+	signal(SIGINT, child_handler);
+	signal(SIGQUIT, child_handler);
+}
+
 static void	sig_handler(int signo)
 {
 	if (signo == SIGINT)

--- a/src/main.c
+++ b/src/main.c
@@ -48,7 +48,7 @@ int	exec_func(t_cmd *cmd, t_lst **env_lst)
 	{
 		path_arr = path_parsing(cmd->argv[0], *env_lst);
 		pid = fork();
-		
+
 			if (exec_built_in_func(cmd->argv, env_lst) == 1)
 			{
 				path = path_is_valid(cmd->argv[0], path_arr);
@@ -82,7 +82,7 @@ int	minishell(char *envp[])
 	init_env_lst(&env_lst, envp);
 	while (1)
 	{
-		//handle_signal();
+		handle_signal();
 		input = readline("minishell42 $ ");
 		if (!input)
 		{

--- a/src/mini_cd.c
+++ b/src/mini_cd.c
@@ -63,8 +63,8 @@ int	mini_cd(char *argv[], t_lst *env_lst)
 	path = argv[1];
 	if (!path || ft_strcmp(path, "~") == 0)
 	{
-	 	free(path);
-	 	path = set_home_path(env_lst);
+		free(path);
+		path = set_home_path(env_lst);
 	}
 	if (!path)
 	{

--- a/src/parse_case_dquote.c
+++ b/src/parse_case_dquote.c
@@ -71,11 +71,7 @@ static void	fill_str(char *input, int *i, t_lst *env_lst, char **str)
 			free(env_str);
 		}
 		else
-		{
-			(*str)[idx] = input[*i];
-			idx++;
-			(*i)++;
-		}
+			(*str)[idx++] = input[(*i)++];
 	}
 	if (input[*i] == '$')
 	{

--- a/src/parse_case_none.c
+++ b/src/parse_case_none.c
@@ -81,11 +81,7 @@ static void	fill_str(char *input, int *i, t_lst *env_lst, char **str)
 			free(env_str);
 		}
 		else
-		{
-			(*str)[idx] = input[*i];
-			idx++;
-			(*i)++;
-		}
+			(*str)[idx++] = input[(*i)++];
 	}
 }
 

--- a/src/redirect.c
+++ b/src/redirect.c
@@ -23,7 +23,8 @@ static int	redirect_error(t_token *curr, int fd_in)
 {
 	if (!curr->next)
 	{
-		write(2, "minishell42: syntax error near unexpected token `newline'\n", 59);
+		write(2, "minishell42: syntax error \
+		near unexpected token `newline'\n", 59);
 		return (1);
 	}
 	if (fd_in < 0)


### PR DESCRIPTION
시그널
ctrl + c
ctrl + \
부분 배쉬랑 똑같이 처리

리다이렉션
함수 쪼개면서 안된 케이스
수정
단일빌트인일때 표준입출력을 다시 안되돌려줘서 그럼

그리고 리다이렉션 이랑 파이프 혼합일때
리다이렉션이 우선순위가 높아야 하는데
if 리다이렉션
if 파이프
이런식으로 써서 리다이렉션 값이 덮어씌워진 부분
if
else if
로 해결

다른 자잘한 놈체크도 같이 해줌